### PR TITLE
Removing version constraint on d3m package.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-d3m>=v2019.11.10
+d3m
 langdetect>=1.0.7
 python-dateutil>=2.5.2
 six>=1.10.0


### PR DESCRIPTION
Not the best thing to do, but it allows us to install these primitives against devel version of the core package as well.

Please resubmit primitive annotations using this, if you approve this change.